### PR TITLE
installation: Python-2.7 and Python-3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2018 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software
@@ -28,7 +28,11 @@ cache:
   - pip
 
 python:
-  - "3.5"
+  - "2.7"
+  - "3.6"
+
+matrix:
+  fast_finish: true
 
 before_install:
   - travis_retry pip install --upgrade pip setuptools py

--- a/setup.py
+++ b/setup.py
@@ -100,15 +100,20 @@ setup(
     setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
+        'Development Status :: 3 - Alpha',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology'
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python',
         'Topic :: System :: Clustering',
         'Topic :: System :: Systems Administration'
         'Topic :: Utilities',
-        'Development Status :: 3 - Alpha',
     ],
 )


### PR DESCRIPTION
* Declares explicit Python versions 2.7 and 3.6.

* Enriches Travis CI test matrix accordingly.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>