### PR TITLE
configurations: fix extraneous QUEUE_ENV setting

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -106,20 +106,20 @@ Example:
   components:
     reana-workflow-controller:
       type: "docker"
-      image: "reanahub/reana-workflow-controller:v0.0.1"
+      image: "reanahub/reana-workflow-controller:0.1.0"
       environment:
         - SHARED_VOLUME_PATH: "/reana"
         - ORGANIZATIONS: "default,alice,atlas,cms,lhcb"
 
     reana-job-controller:
       type: "docker"
-      image: "reanahub/reana-job-controller:v0.0.1"
+      image: "reanahub/reana-job-controller:0.1.0"
       environment:
         - REANA_STORAGE_BACKEND: "LOCAL"
 
     reana-server:
       type: "docker"
-      image: "reanahub/reana-server:v0.0.1"
+      image: "reanahub/reana-server:0.1.0"
       environment:
         - API_HOST: "api"
         - WORKFLOW_CONTROLLER_SERVICE_HOST: "0.0.0.0"
@@ -127,24 +127,21 @@ Example:
 
     reana-message-broker:
       type: "docker"
-      image: "reanahub/reana-message-broker:v0.0.1"
+      image: "reanahub/reana-message-broker:0.1.0"
       environment:
         - API_HOST: "api"
 
     reana-workflow-monitor:
       type: "docker"
-      image: "reanahub/reana-workflow-monitor:v0.0.1"
+      image: "reanahub/reana-workflow-monitor:0.1.0"
       environment:
         - API_HOST: "api"
 
     reana-workflow-engine-yadage:
       type: "docker"
-      image: "reanahub/reana-workflow-engine-yadage:v0.0.1"
+      image: "reanahub/reana-workflow-engine-yadage:0.1.0"
       environment:
         - ZMQ_PROXY_CONNECT: "tcp://zeromq-msg-proxy.default.svc.cluster.local:8666"
-        - QUEUE_ENV: "yadage-default-queue"
-        - REANA_WORKFLOW_ENGINE_YADAGE_EXPERIMENT: "default"
-        - SHARED_VOLUME: "/data"
 
 
 Initialize a REANA cluster

--- a/reana_cluster/configurations/reana-cluster.yaml
+++ b/reana_cluster/configurations/reana-cluster.yaml
@@ -34,6 +34,3 @@ components:
     image: "reanahub/reana-workflow-engine-yadage:0.1.0"
     environment:
       - ZMQ_PROXY_CONNECT: "tcp://zeromq-msg-proxy.default.svc.cluster.local:8666"
-      - QUEUE_ENV: "yadage-default-queue"
-      - REANA_WORKFLOW_ENGINE_YADAGE_EXPERIMENT: "default"
-      - SHARED_VOLUME: "/data"


### PR DESCRIPTION
* Removes extraneous QUEUE_ENV setting in ``reana-cluster.yaml`` that were
  causing workers for other organisations (such as "cms") to run also "default"
  workflows. This was making the "default" workflows not to run if we did not
  hit the correct worker.

* Amends documentation to reflect v0.1.0 components.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>