### PR TITLE
config: remove FLASK_DEBUG environment variable

### DIFF
--- a/docs/developerguide.rst
+++ b/docs/developerguide.rst
@@ -155,7 +155,6 @@ After running ``minikube start`` on the remote host.
          - ORGANIZATIONS: "default,alice,atlas,cms,lhcb"
          - WDB_SOCKET_SERVER: "wdb"
          - WDB_NO_BROWSER_AUTO_OPEN: "True"
-         - FLASK_DEBUG: "1"
 
      reana-job-controller:
        type: "docker"
@@ -168,7 +167,6 @@ After running ``minikube start`` on the remote host.
          - REANA_STORAGE_BACKEND: "LOCAL"
          - WDB_SOCKET_SERVER: "wdb"
          - WDB_NO_BROWSER_AUTO_OPEN: "True"
-         - FLASK_DEBUG:  "1"
 
      reana-server:
        type: "docker"
@@ -180,7 +178,6 @@ After running ``minikube start`` on the remote host.
        environment:
          - WDB_SOCKET_SERVER: "wdb"
          - WDB_NO_BROWSER_AUTO_OPEN: "True"
-         - FLASK_DEBUG: "1"
 
      reana-message-broker:
        type: "docker"
@@ -204,7 +201,6 @@ After running ``minikube start`` on the remote host.
          - ZMQ_PROXY_CONNECT: tcp://zeromq-msg-proxy.default.svc.cluster.local:8667
          - WDB_SOCKET_SERVER: "wdb"
          - WDB_NO_BROWSER_AUTO_OPEN: "True"
-         - FLASK_DEBUG: "1"
 
      reana-workflow-engine-yadage:
        type: "docker"

--- a/reana_cluster/configurations/reana-cluster-dev.yaml
+++ b/reana_cluster/configurations/reana-cluster-dev.yaml
@@ -24,7 +24,6 @@ components:
       - ORGANIZATIONS: "default,alice,atlas,cms,lhcb"
       - WDB_SOCKET_SERVER: "wdb"
       - WDB_NO_BROWSER_AUTO_OPEN: "True"
-      - FLASK_DEBUG: "1"
 
   reana-job-controller:
     type: "docker"
@@ -37,7 +36,6 @@ components:
       - REANA_STORAGE_BACKEND: "LOCAL"
       - WDB_SOCKET_SERVER: "wdb"
       - WDB_NO_BROWSER_AUTO_OPEN: "True"
-      - FLASK_DEBUG:  "1"
 
   reana-server:
     type: "docker"
@@ -49,7 +47,6 @@ components:
     environment:
       - WDB_SOCKET_SERVER: "wdb"
       - WDB_NO_BROWSER_AUTO_OPEN: "True"
-      - FLASK_DEBUG: "1"
 
   reana-message-broker:
     type: "docker"
@@ -73,7 +70,6 @@ components:
       - ZMQ_PROXY_CONNECT: tcp://zeromq-msg-proxy.default.svc.cluster.local:8667
       - WDB_SOCKET_SERVER: "wdb"
       - WDB_NO_BROWSER_AUTO_OPEN: "True"
-      - FLASK_DEBUG: "1"
 
   reana-workflow-engine-yadage:
     type: "docker"


### PR DESCRIPTION
* Initially we added `FLASK_DEBUG` to all our Flask intances to enable
  reloading after code changes. However, we have found out that Flask
  reload is triggered continuously because `minikube mount`, used to
  share the code between host  and `minikube` `vm`, updates files
  continuously.