### PR TITLE
docs: minikube/kubectl prerequisite details

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -10,7 +10,8 @@ Deploy REANA cluster locally
 
 Are you looking at installing and deploying REANA cluster locally on your laptop?
 
-1. Install Minikube following `minikube installation guide <https://kubernetes.io/docs/getting-started-guides/minikube/#installation>`_.
+1. Install `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
+   and `minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
 
 2. Start Minikube virtual machine:
 


### PR DESCRIPTION
* Adds more details concerning working verions of kubectl/minikube on Arch Linux
  for REANA v0.1.0. (Other combinations, such as too-new versions, or too-old
  versions, were leading to DNS-like troubles where REANA workers couldn't see
  message broker.)

* Amends parts of the documentation to improve verbiage or to add illustrative
  outputs.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>