### PR TITLE
cluster: shared volume mounting in job-ctlr

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/deployments/job-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/job-controller-template.yaml
@@ -28,6 +28,8 @@ spec:
         volumeMounts:
         - name: svaccount
           mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+        - mountPath: "/reana"
+          name: reana-shared-volume
         {% set mountpoints=RJC_MOUNTPOINTS %}
         {% for mount in mountpoints %}
         - mountPath: {{mount['path'].split(':')[1]}}
@@ -49,6 +51,22 @@ spec:
       - name: svaccount
         secret:
           secretName: {{K8S_APISERVER_SECRET}}
+      - name: reana-shared-volume
+        {% if DEPLOYMENT == 'prod' %}
+        cephfs:
+          monitors:
+          {% for monitor in CEPHFS_MONITORS  %}
+           - {{monitor}}
+          {% endfor %}
+          path: {{ROOT_PATH}}
+          user: {{CEPHFS_USER}}
+          secretRef:
+            name: {{CEPHFS_SECRET_NAME}}
+          readOnly: {{CEPHFS_READONLY}}
+        {% else %}
+        hostPath:
+          path: {{ROOT_PATH}}
+        {% endif %}
       {% for mount in mountpoints %}
       - name: {{mount['name']}}
         {{mount['type']}}:

--- a/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
@@ -45,6 +45,14 @@ spec:
         image: {{WORKFLOW_CONTROLLER_IMAGE}}
         command: ["flask", "consume-job-queue"]
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
+        volumeMounts:
+        - mountPath: "/reana"
+          name: reana-shared-volume
+        {% set mountpoints=RWFC_MOUNTPOINTS %}
+        {% for mount in mountpoints %}
+        - mountPath: {{mount['path'].split(':')[1]}}
+          name: {{mount['name']}}
+        {% endfor %}
         env:
         {% set environment=RWFC_ENVIRONMENT %}
         {% for envvar in environment %}

--- a/reana_cluster/configurations/reana-cluster-dev.yaml
+++ b/reana_cluster/configurations/reana-cluster-dev.yaml
@@ -36,6 +36,7 @@ components:
         path: "/code/reana-job-controller:/code"
     environment:
       - <<: *db_base_config
+      - SHARED_VOLUME_PATH: "/reana"
       - REANA_STORAGE_BACKEND: "LOCAL"
       - WDB_SOCKET_SERVER: "wdb"
       - WDB_NO_BROWSER_AUTO_OPEN: "True"


### PR DESCRIPTION
* ADD shared volume mounting to job-controller and job-status-consumer, in order to calculate workspace hashes for caching.