### PR TITLE
templates: stdin tty true for python component

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/deployments/cwl-default-worker.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/cwl-default-worker.yaml
@@ -13,6 +13,10 @@ spec:
       containers:
       - name: cwl-default-worker
         image: {{WORKFLOW_ENGINE_CWL_IMAGE}}
+        {%- if DEPLOYMENT != 'prod' %}
+        tty: true
+        stdin: true
+        {% endif %}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
         env:
         - name: QUEUE_ENV

--- a/reana_cluster/backends/kubernetes/templates/deployments/job-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/job-controller-template.yaml
@@ -14,6 +14,10 @@ spec:
       - name: job-controller
         image: {{JOB_CONTROLLER_IMAGE}}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
+        {%- if DEPLOYMENT != 'prod' %}
+        tty: true
+        stdin: true
+        {% endif %}
         ports:
         - containerPort: 5000
           name: http

--- a/reana_cluster/backends/kubernetes/templates/deployments/serial-default-worker.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/serial-default-worker.yaml
@@ -14,6 +14,10 @@ spec:
       - name: serial-default-worker
         image: {{WORKFLOW_ENGINE_SERIAL_IMAGE}}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
+        {%- if DEPLOYMENT != 'prod' %}
+        tty: true
+        stdin: true
+        {% endif %}
         env:
         - name: QUEUE_ENV
           value: serial-default-queue

--- a/reana_cluster/backends/kubernetes/templates/deployments/server-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/server-template.yaml
@@ -14,6 +14,10 @@ spec:
       - name: server
         image: {{SERVER_IMAGE}}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
+        {%- if DEPLOYMENT != 'prod' %}
+        tty: true
+        stdin: true
+        {% endif %}
         volumeMounts:
         - mountPath: "/reana"
           name: reana-shared-volume

--- a/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
@@ -14,6 +14,10 @@ spec:
       - name: rest
         image: {{WORKFLOW_CONTROLLER_IMAGE}}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
+        {%- if DEPLOYMENT != 'prod' %}
+        tty: true
+        stdin: true
+        {% endif %}
         volumeMounts:
         - mountPath: "/reana"
           name: reana-shared-volume

--- a/reana_cluster/backends/kubernetes/templates/deployments/workflow-monitor-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/workflow-monitor-template.yaml
@@ -14,6 +14,10 @@ spec:
       - name: workflow-monitor
         image: {{WORKFLOW_MONITOR_IMAGE}}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
+        {%- if DEPLOYMENT != 'prod' %}
+        tty: true
+        stdin: true
+        {% endif %}
         volumeMounts:
         {% set mountpoints=RWM_MOUNTPOINTS %}
         {% for mount in mountpoints %}

--- a/reana_cluster/backends/kubernetes/templates/deployments/yadage-default-worker.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/yadage-default-worker.yaml
@@ -14,6 +14,10 @@ spec:
       - name: yadage-default-worker
         image: {{WORKFLOW_ENGINE_YADAGE_IMAGE}}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
+        {%- if DEPLOYMENT != 'prod' %}
+        tty: true
+        stdin: true
+        {% endif %}
         env:
         - name: QUEUE_ENV
           value: yadage-default-queue


### PR DESCRIPTION
* Using the ``stdin`` and ``tty`` options for container specs
  see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#container-v1-core
  a tty and stdin buffer are allocated allowing to, for example,
  set ipdb debug breakpoints inside containers and attach to them
  doing ``kubectl attach -ti job-controller-xxx-yy-zz``.