### PR TITLE
templates: use hostPath for DB deployment

### DIFF
--- a/reana_cluster/backends/kubernetes/k8s.py
+++ b/reana_cluster/backends/kubernetes/k8s.py
@@ -179,6 +179,10 @@ class KubernetesBackend(ReanaBackendABC):
                     backend_conf_parameters['CEPHFS_MONITORS'] = \
                         cluster_spec['cluster'].get('cephfs_monitors')
 
+                if cluster_spec['cluster'].get('db_persistence_path'):
+                    backend_conf_parameters['DB_PERSISTENCE_PATH'] = \
+                        cluster_spec['cluster'].get('db_persistence_path')
+
                 # Would it be better to combine templates or populated
                 # templates in Python code for improved extensibility?
                 # Just drop a .yaml template and add necessary to config.yaml

--- a/reana_cluster/backends/kubernetes/templates/deployments/db-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/db-template.yaml
@@ -26,7 +26,8 @@ spec:
           value: reana
         volumeMounts:
           - name: data
-            mountPath: /var/lib/pgsql/data
+            mountPath: /var/lib/postgresql/data
       volumes:
         - name: data
-          emptyDir: {}
+          hostPath:
+            path: {{DB_PERSISTENCE_PATH}}

--- a/reana_cluster/configurations/reana-cluster-dev.yaml
+++ b/reana_cluster/configurations/reana-cluster-dev.yaml
@@ -10,6 +10,7 @@ cluster:
   version: "v1.9.4"
   db_config: &db_base_config
     - REANA_SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://reana:reana@db:5432/reana"
+  db_persistence_path: "/reanadb"
 
 components:
   reana-workflow-controller:

--- a/reana_cluster/configurations/reana-cluster.yaml
+++ b/reana_cluster/configurations/reana-cluster.yaml
@@ -3,7 +3,7 @@ cluster:
   version: "v1.9.4"
   db_config: &db_base_config
     - REANA_SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://reana:reana@db:5432/reana"
-  root_path: "/tmp/reana"
+  root_path: "/reana"
 
 components:
   reana-workflow-controller:


### PR DESCRIPTION
* Prevents DB to be destroyed when running locally or deploying on
  a single node cluster. This is NOT save when deploying on a multi
  node deplyoment since DB pod could be redeployed for different
  reasons to other VMs, loosing all database content. This is ok
  since multi node setups will be in production and they will use
  DBoD (closes reanahub/reana-workflow-controller#52).