### PR TITLE
configurations: db_persistence_path fix in latest configuration

### DIFF
--- a/reana_cluster/configurations/reana-cluster-latest.yaml
+++ b/reana_cluster/configurations/reana-cluster-latest.yaml
@@ -3,6 +3,7 @@ cluster:
   version: "v1.9.4"
   db_config: &db_base_config
     - REANA_SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://reana:reana@db:5432/reana"
+  db_persistence_path: "/reanadb"
 
 components:
   reana-workflow-controller:

--- a/reana_cluster/configurations/reana-cluster.yaml
+++ b/reana_cluster/configurations/reana-cluster.yaml
@@ -4,6 +4,7 @@ cluster:
   db_config: &db_base_config
     - REANA_SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://reana:reana@db:5432/reana"
   root_path: "/reana"
+  db_persistence_path: "/reanadb"
 
 components:
   reana-workflow-controller:


### PR DESCRIPTION
* Adds ``db_persistence_path`` in the ``latest`` configuration file as well,
  fixing problems during cluster initialisation. (see #102)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>