### PR TITLE
templates: exit when one command fails

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/deployments/server-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/server-template.yaml
@@ -15,7 +15,7 @@ spec:
         image: {{SERVER_IMAGE}}
         {% if DEPLOYMENT != 'prod' %}
         command: ["/bin/sh","-c"]
-        args: ["flask db init; flask users create_default info@reana.io; flask run --host=0.0.0.0"]
+        args: ["set -e; flask db init; flask users create_default info@reana.io; flask run --host=0.0.0.0"]
         {% endif %}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
         {%- if DEPLOYMENT != 'prod' %}


### PR DESCRIPTION
* For REANA v0.3.0 server should exit if the database could not be
  created (addresses reanahub/reana-server#79).

Connects reanahub/reana-server#79.