### PR TITLE
installation: more version limits

### DIFF
--- a/reana_cluster/version.py
+++ b/reana_cluster/version.py
@@ -27,4 +27,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.3.0"
+__version__ = "0.3.1.dev20180905"

--- a/setup.py
+++ b/setup.py
@@ -62,13 +62,13 @@ setup_requires = [
 ]
 
 install_requires = [
-    'click>=6.7',
-    'Jinja2>=2.9.6',
-    'jsonschema>=2.6.0',
-    'kubernetes>=6.0.0',
-    'PyYAML>=3.12',
+    'click>=6.7,<6.8',
+    'Jinja2>=2.9.6,<2.11',
+    'jsonschema>=2.6.0,<2.7',
+    'kubernetes>=6.0.0,<7.1',
+    'PyYAML>=3.12,<3.14',
     'reana-commons>=0.3.1,<0.4',
-    'tablib>=0.12.1',
+    'tablib>=0.12.1,<0.13',
     'urllib3==1.22',
 ]
 


### PR DESCRIPTION
* Introduces more upper boundary limits for dependencies to make sure all the
  client components are installable from PyPI in the future.
  (addresses reanahub/reana#80)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>