### PR TITLE
docs: upgrade compatible k8s and minikube versions

### DIFF
--- a/docs/developerguide.rst
+++ b/docs/developerguide.rst
@@ -157,7 +157,7 @@ After running ``minikube start`` on the remote host.
      type: "kubernetes"
      config: "./development-kubeconfig.yaml"
      config_context: "minikube"
-     version: "v1.6.4"
+     version: "v1.11.2"
      url: "https://localhost:8443"
 
    components:
@@ -524,8 +524,8 @@ Now we create a new cluster to host a new ``reana`` version (0.1.0):
 
 .. code:: console
 
-    $ minikube start --profile reana-0.1.0 --kubernetes-version="v1.6.4"
-    Starting local Kubernetes v1.6.4 cluster...
+    $ minikube start --profile reana-0.1.0 --kubernetes-version="v1.11.2"
+    Starting local Kubernetes v1.11.2 cluster...
     Starting VM...
     Getting VM IP address...
     Moving files into cluster...
@@ -588,7 +588,7 @@ context:
       # If not specified will use the value of `current-context:` key of kubeconfig.
     - # config_context: "minikube"
     + config_context: "reana-0.1.0"
-      version: "v1.6.4"
+      version: "v1.11.2"
       url: "http://localhost"
 
 And now you can start the cluster as ``reana-cluster`` docs say:
@@ -649,8 +649,8 @@ Now we can restart the cluster:
 
 .. code:: console
 
-    $ minikube start --profile minikube --kubernetes-version="v1.6.4"
-    Starting local Kubernetes v1.6.4 cluster...
+    $ minikube start --profile minikube --kubernetes-version="v1.11.2"
+    Starting local Kubernetes v1.11.2 cluster...
     Starting VM...
     Getting VM IP address...
     Moving files into cluster...

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -13,7 +13,7 @@ Are you looking at installing and deploying REANA cluster locally on your laptop
 1. Install `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
    (e.g. version 1.11.2) and `minikube
    <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_ (e.g. version
-   0.28.0):
+   0.28.2):
 
    .. code-block:: console
 
@@ -23,7 +23,7 @@ Are you looking at installing and deploying REANA cluster locally on your laptop
 
    .. code-block:: console
 
-      $ minikube start --kubernetes-version="v1.9.4"
+      $ minikube start --kubernetes-version="v1.11.2"
 
 3. Install REANA-Cluster sources. You probably want to use a virtual environment:
 
@@ -96,26 +96,6 @@ Deploy on CERN infrastructure
 2. `Setup your OpenStack account <https://clouddocs.web.cern.ch/clouddocs/tutorial/create_your_openstack_profile.html>`_
    and create a Kubernetes cluster following the
    `official documentation <https://clouddocs.web.cern.ch/clouddocs/containers/quickstart.html#kubernetes>`_.
-
-.. note::
-
-   For now, you will have to create the cluster with Kubernetes version
-   1.9.3 since 1.10.1 introduces a
-   `bug with backoff limit <https://github.com/kubernetes/kubernetes/issues/54870>`_.
-
-   .. code-block:: console
-
-      $ openstack coe cluster create reana-cloud --keypair mykey
-          --node-count 1
-          --cluster-template kubernetes
-          --master-flavor m2.medium
-          --flavor m2.medium
-          --labels influx_grafana_dashboard_enabled=true
-          --labels kube_tag="v1.9.3"
-          --labels cvmfs_tag=qa
-          --labels flannel_backend=vxlan
-          --labels container_infra_prefix=gitlab-registry.cern.ch/cloud/atomic-system-containers/
-          --labels ingress_controller=traefik
 
 .. note::
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -14,7 +14,7 @@ depends on your operating system.
 Versions
 ~~~~~~~~
 
-For REANA v0.3.0, ``kubectl 1.9.4`` and ``minikube 0.28.0`` are known to work
+For REANA v0.3.0, ``kubectl 1.11.2`` and ``minikube 0.28.2`` are known to work
 well.
 
 Arch Linux
@@ -45,20 +45,20 @@ Here is one example of well-working versions for REANA v0.2.0:
 .. code-block:: console
 
    $ pacman -Q | grep -iE '(docker|virtualbox|kube|qemu|libvirt)'
-   docker 1:18.05.0-2
-   docker-compose 1.21.2-1
-   docker-machine 0.14.0-1
+   docker 1:18.06.0-1
+   docker-compose 1.22.0-2
+   docker-machine 0.15.0-1
    docker-machine-driver-kvm2 0.27.0-1
-   kubectl-bin 1.10.3-1
-   libvirt 4.4.0-3
-   minikube 0.28.0-1
-   python-docker 3.4.1-1
-   python-docker-pycreds 0.3.0-1
-   python-dockerpty 0.4.1-2
-   qemu 2.12.0-1
-   virtualbox 5.2.14-1
-   virtualbox-guest-iso 5.2.14-1
-   virtualbox-host-modules-arch 5.2.14-1
+   kubectl-bin 1.11.2-1
+   libvirt 4.6.0-3
+   minikube 0.28.2-1
+   python-docker 3.5.0-1
+   python-docker-pycreds 0.3.0-2
+   python-dockerpty 0.4.1-3
+   qemu 3.0.0-1
+   virtualbox 5.2.18-1
+   virtualbox-guest-iso 5.2.18-1
+   virtualbox-host-modules-arch 5.2.18-7
 
 Start minikube
 --------------
@@ -68,19 +68,19 @@ running:
 
 .. code-block:: console
 
-   $ minikube start --kubernetes-version="v1.9.4"
+   $ minikube start --kubernetes-version="v1.11.2"
 
 or, in case of KVM2 hypervisor:
 
 .. code-block:: console
 
-   $ minikube start --kubernetes-version="v1.9.4" --vm-driver=kvm2
+   $ minikube start --kubernetes-version="v1.11.2" --vm-driver=kvm2
 
 You will see an output like:
 
 .. code-block:: console
 
-   Starting local Kubernetes v1.9.4 cluster...
+   Starting local Kubernetes v1.11.2 cluster...
    Starting VM...
    Getting VM IP address...
    Moving files into cluster...

--- a/reana_cluster/backends/kubernetes/k8s.py
+++ b/reana_cluster/backends/kubernetes/k8s.py
@@ -51,8 +51,8 @@ class KubernetesBackend(ReanaBackendABC):
     _conf = {
         'templates_folder': pkg_resources.resource_filename(
             __name__, '/templates'),
-        'min_version': 'v1.9.4',
-        'max_version': 'v1.9.4',
+        'min_version': 'v1.11.2',
+        'max_version': 'v1.11.2',
     }
 
     def __init__(self,

--- a/reana_cluster/configurations/reana-cluster-dev.yaml
+++ b/reana_cluster/configurations/reana-cluster-dev.yaml
@@ -7,7 +7,7 @@ cluster:
 
   # Specifies which K8S context from the kubeconfig configuration will be used.
   # If not specified will use the value of `current-context:` key of kubeconfig.
-  version: "v1.9.4"
+  version: "v1.11.2"
   db_config: &db_base_config
     - REANA_SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://reana:reana@db:5432/reana"
   db_persistence_path: "/reanadb"

--- a/reana_cluster/configurations/reana-cluster-latest.yaml
+++ b/reana_cluster/configurations/reana-cluster-latest.yaml
@@ -1,6 +1,6 @@
 cluster:
   type: "kubernetes"
-  version: "v1.9.4"
+  version: "v1.11.2"
   db_config: &db_base_config
     - REANA_SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://reana:reana@db:5432/reana"
   db_persistence_path: "/reanadb"

--- a/reana_cluster/configurations/reana-cluster.yaml
+++ b/reana_cluster/configurations/reana-cluster.yaml
@@ -1,6 +1,6 @@
 cluster:
   type: "kubernetes"
-  version: "v1.9.4"
+  version: "v1.11.2"
   db_config: &db_base_config
     - REANA_SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://reana:reana@db:5432/reana"
   root_path: "/reana"


### PR DESCRIPTION
* Removes note about creating custom CERN k8s cluster template
  since k8s 1.11.2 has been deployed.