### PR TITLE
cluster: default job-controller storage to LOCAL

### DIFF
--- a/reana_cluster/configurations/reana-cluster.yaml
+++ b/reana_cluster/configurations/reana-cluster.yaml
@@ -25,7 +25,7 @@ components:
     environment:
       - <<: *db_base_config
       - SHARED_VOLUME_PATH: "/reana"
-      - REANA_STORAGE_BACKEND: "CEPHFS"
+      - REANA_STORAGE_BACKEND: "LOCAL"
 
   reana-server:
     type: "docker"


### PR DESCRIPTION
* Revert default option for spawned jobs to use hostpath instead of
  CephFS, so that a cluster is functional by default.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>