### PR TITLE
templates: reverts usage of Flask run

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/deployments/job-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/job-controller-template.yaml
@@ -14,7 +14,8 @@ spec:
       - name: job-controller
         image: {{JOB_CONTROLLER_IMAGE}}
         {% if DEPLOYMENT != 'prod' %}
-        command: ["flask", "run", "-h", "0.0.0.0"]
+        command: ["/bin/sh","-c"]
+        args: ["python reana_job_controller/app.py"]
         {% endif %}
         imagePullPolicy: {{IMAGE_PULL_POLICY}}
         {%- if DEPLOYMENT != 'prod' %}


### PR DESCRIPTION
* Flask run depends on a yet not released PR, so we need to revert for now.

Reverting as R-J-Controller doesn't start until https://github.com/reanahub/reana-job-controller/pull/98 is merged.