### PR TITLE
docs: increase Minikube VM memory

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -68,6 +68,7 @@ running:
 
 .. code-block:: console
 
+   $ minikube config set memory 4096
    $ minikube start --kubernetes-version="v1.11.2"
 
 or, in case of KVM2 hypervisor:


### PR DESCRIPTION
* Since we have been experiencing many problems with pods not
  not being able to start due to memory allocation problems
  we increase by default the memory for the Minikube VM.