### PR TITLE
installation: use fixed port for `wdb`

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/backend_conf.yaml
+++ b/reana_cluster/backends/kubernetes/templates/backend_conf.yaml
@@ -2,20 +2,20 @@
 {% include 'deployments/message-broker-template.yaml' %}
 {% include 'deployments/server-template.yaml' %}
 {% include 'deployments/workflow-controller-template.yaml' %}
-{% include 'deployments/wdb-template.yaml' %}
 {% include 'deployments/db-template.yaml' %}
 {% include 'services/job-controller-template.yaml' %}
 {% include 'services/message-broker-template.yaml' %}
 {% include 'services/server-template.yaml' %}
 {% include 'services/workflow-controller-template.yaml' %}
-{% include 'services/wdb-template.yaml' %}
 {% include 'services/db-template.yaml' %}
 {% include 'clusterrole/service-reader.yaml' %}
 {% include 'clusterrolebinding/service-reader.yaml' %}
 {% include 'ingress/reana-ingress.yaml' %}
+{%- if DEBUG %}
+{% include 'deployments/wdb-template.yaml' %}
+{% include 'services/wdb-template.yaml' %}
+{%- endif %}
 {%- if CEPHFS %}
 {% include 'storageclasses/ceph.yaml' %}
 {% include 'persistentvolumeclaims/ceph.yaml' %}
-{%- else %}
-{% include 'deployments/wdb-template.yaml' %}
 {%- endif %}

--- a/reana_cluster/backends/kubernetes/templates/services/wdb-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/services/wdb-template.yaml
@@ -12,6 +12,7 @@ spec:
     protocol: TCP
   - port: 1984
     targetPort: 1984
+    nodePort: 31984
     name: "ui"
     protocol: TCP
   selector:


### PR DESCRIPTION
* Avoid deploying `wdb` in production since it could be a potential security
  vulnerability (closes #72).

* Sets `wdb` nodeport to a fixed port so developers can always use
  the same URL, $(minikube ip):31984 (closes #173).