### PR TITLE
cluster: pin wdb image to the older version because the newest fails

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/deployments/wdb-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/wdb-template.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: wdb
-        image: kozea/wdb
+        image: kozea/wdb:3.2.5
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 1984


### PR DESCRIPTION
When trying to run latest wdb image in cluster it fails with a message:
```console
Traceback (most recent call last):
  File "/Users/rokas/.virtualenvs/virtualenv/bin/wdb.server.py", line 10, in <module>
    from wdb_server import server
  File "/Users/rokas/.virtualenvs/virtualenv/lib/python3.7/site-packages/wdb_server/__init__.py", line 374, in <module>
    raise_error=False
TypeError: fetch() got multiple values for argument 'raise_error'
```
This PR is pinning the image to the version 3.2.5 (second latest at the moment) until they the latest version is fixed.