### PR TITLE
templates: fix REANA DB username env var name

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/deployments/server-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/server-template.yaml
@@ -40,7 +40,7 @@ spec:
         {% endfor %}
         {% endfor %}
         {% if not DEBUG %}
-        - name: REANA_DB_USER
+        - name: REANA_DB_USERNAME
           valueFrom:
             secretKeyRef:
               name: reana-db-secrets
@@ -72,7 +72,7 @@ spec:
         {% endfor %}
         {% endfor %}
         {% if not DEBUG %}
-        - name: REANA_DB_USER
+        - name: REANA_DB_USERNAME
           valueFrom:
             secretKeyRef:
               name: reana-db-secrets

--- a/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
@@ -48,7 +48,7 @@ spec:
         {% endfor %}
         {% endfor %}
         {% if not DEBUG %}
-        - name: REANA_DB_USER
+        - name: REANA_DB_USERNAME
           valueFrom:
             secretKeyRef:
               name: reana-db-secrets
@@ -75,7 +75,7 @@ spec:
         {% endfor %}
         {% endfor %}
         {% if not DEBUG %}
-        - name: REANA_DB_USER
+        - name: REANA_DB_USERNAME
           valueFrom:
             secretKeyRef:
               name: reana-db-secrets


### PR DESCRIPTION
* REANA-DB expects the username to be set as environment variable
  `REANA_DB_USERNAME` instead of `REANA_DB_USER`.