### PR TITLE
cli: add flag to deploy with EOS support

### DIFF
--- a/reana_cluster/backends/kubernetes/k8s.py
+++ b/reana_cluster/backends/kubernetes/k8s.py
@@ -49,6 +49,7 @@ class KubernetesBackend(ReanaBackendABC):
                  cluster_conf=None,
                  kubeconfig=None,
                  kubeconfig_context=None,
+                 eos=False,
                  cephfs=False,
                  cephfs_volume_size=None,
                  cephfs_storageclass=None,
@@ -74,6 +75,7 @@ class KubernetesBackend(ReanaBackendABC):
 
         :param kubeconfig_context: set the active context. If is set to `None`,
             current_context from config file will be used.
+        :param eos: Boolean flag toggling the mount of EOS volume for jobs.
         :param cephfs: Boolean flag toggling the usage of a cephfs volume as
             storage backend.
         :param cephfs_volume_size: Int number which represents cephfs volume
@@ -116,6 +118,7 @@ class KubernetesBackend(ReanaBackendABC):
         self.cluster_conf = cluster_conf or \
             self.generate_configuration(
                 cluster_spec,
+                eos=eos,
                 cephfs=cephfs,
                 cephfs_volume_size=cephfs_volume_size,
                 cephfs_storageclass=cephfs_storageclass,
@@ -156,7 +159,7 @@ class KubernetesBackend(ReanaBackendABC):
 
     @classmethod
     def generate_configuration(
-            cls, cluster_spec, cvmfs=False, cephfs=False,
+            cls, cluster_spec, cephfs=False, eos=False,
             cephfs_volume_size=None,
             cephfs_storageclass=None,
             cephfs_os_share_id=None,
@@ -166,6 +169,7 @@ class KubernetesBackend(ReanaBackendABC):
 
         :param cluster_spec: Dictionary representing complete REANA
             cluster spec file.
+        :param eos: Boolean flag toggling the mount of EOS volume for jobs.
         :param cephfs: Boolean which represents whether REANA is
             deployed with CEPH or not.
         :param cephfs_volume_size: Int to set CEPH volume size in GB.
@@ -212,6 +216,10 @@ class KubernetesBackend(ReanaBackendABC):
                         cluster_spec['cluster'].get(
                             'cephfs_os_share_access_id',
                             cephfs_os_share_access_id)
+
+                if eos or cluster_spec['cluster'].get('eos'):
+                    backend_conf_parameters['EOS'] = \
+                        cluster_spec['cluster'].get('eos', eos)
 
                 if debug or cluster_spec['cluster'].get('debug'):
                     backend_conf_parameters['DEBUG'] = True

--- a/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
@@ -41,6 +41,10 @@ spec:
         - name: REANA_URL
           value: {{REANA_URL}}
         {% endif %}
+        {% if EOS %}
+        - name: K8S_CERN_EOS_AVAILABLE
+          value: "True"
+        {% endif %}
         - name: REANA_DEPLOYMENT_TYPE
           value: {{DEPLOYMENT}}
         {% if CEPHFS %}

--- a/reana_cluster/cli/__init__.py
+++ b/reana_cluster/cli/__init__.py
@@ -52,6 +52,10 @@ class Config(object):
     help='If set, specifications file is not validated before '
          'starting the initialization.')
 @click.option(
+    '--eos', is_flag=True,
+    help='If EOS is available in the deployed cluster, this config will '
+         'make it available inside the REANA jobs.')
+@click.option(
     '--cephfs', is_flag=True,
     help='Set cephfs volume for cluster storage.')
 @click.option(
@@ -78,7 +82,7 @@ class Config(object):
     '--ui', is_flag=True,
     help='Deploy the REANA-UI inside the REANA Cluster.')
 @click.pass_context
-def cli(ctx, loglevel, skip_validation, file,
+def cli(ctx, loglevel, skip_validation, file, eos,
         cephfs, cephfs_volume_size, cephfs_storageclass, cephfs_os_share_id,
         cephfs_os_share_access_id, debug, url, ui):
     """Command line application for managing a REANA cluster."""
@@ -107,6 +111,7 @@ def cli(ctx, loglevel, skip_validation, file,
                      .format(cluster_type))
         ctx.obj.backend = supported_backends[cluster_type](
             cluster_spec,
+            eos=eos,
             cephfs=cephfs,
             cephfs_volume_size=cephfs_volume_size,
             cephfs_storageclass=cephfs_storageclass,


### PR DESCRIPTION
* Adds a flag to tell the REANA cluster that the Kubernetes where
  it is going to be deployed has EOS available
  (closes reanahub/reana#216).