### PR TITLE
templates: add missing REANA_URL env var

### DIFF
--- a/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
+++ b/reana_cluster/backends/kubernetes/templates/deployments/workflow-controller-template.yaml
@@ -76,6 +76,10 @@ spec:
           name: {{mount['name']}}
         {% endfor %}
         env:
+        {% if REANA_URL %}
+        - name: REANA_URL
+          value: {{REANA_URL}}
+        {% endif %}
         {% set environment=RWFC_ENVIRONMENT %}
         {% for envvar in environment %}
         {% for key, value in envvar.items() %}


### PR DESCRIPTION
This variable is needed to build the [target url in RWC consumer](https://github.com/reanahub/reana-workflow-controller/blob/master/reana_workflow_controller/consumer.py#L94).
Related to https://github.com/reanahub/reana-workflow-controller/pull/263

Addresses reanahub/reana-workflow-controller#249