### PR TITLE
configuration: 'latest' images for minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 before_install:
   - pip install -r requirements-dev.txt
   - travis_retry pip install --upgrade pip setuptools py
-  - travis_retry pip install twine wheel coveralls requirements-builder
+  - travis_retry pip install twine wheel coveralls requirements-builder==0.3.0 click==7.0
   - requirements-builder -e $EXTRAS --level=min setup.py > .travis-lowest-requirements.txt
   - requirements-builder -e $EXTRAS --level=pypi setup.py > .travis-release-requirements.txt
   - requirements-builder -e $EXTRAS --level=dev --req requirements-dev.txt setup.py > .travis-devel-requirements.txt

--- a/reana_cluster/configurations/reana-cluster-minikube.yaml
+++ b/reana_cluster/configurations/reana-cluster-minikube.yaml
@@ -12,21 +12,21 @@ cluster:
 components:
   reana-workflow-controller:
     type: "docker"
-    image: "reanahub/reana-workflow-controller:0.6.0"
+    image: "reanahub/reana-workflow-controller:latest"
     environment:
       - <<: *db_base_config
       - SHARED_VOLUME_PATH: "/var/reana"
-      - REANA_JOB_CONTROLLER_IMAGE: "reanahub/reana-job-controller:0.6.0"
-      - REANA_WORKFLOW_ENGINE_IMAGE_CWL: "reanahub/reana-workflow-engine-cwl:0.6.0"
-      - REANA_WORKFLOW_ENGINE_IMAGE_YADAGE: "reanahub/reana-workflow-engine-yadage:0.6.0"
-      - REANA_WORKFLOW_ENGINE_IMAGE_SERIAL: "reanahub/reana-workflow-engine-serial:0.6.0"
+      - REANA_JOB_CONTROLLER_IMAGE: "reanahub/reana-job-controller:latest"
+      - REANA_WORKFLOW_ENGINE_IMAGE_CWL: "reanahub/reana-workflow-engine-cwl:latest"
+      - REANA_WORKFLOW_ENGINE_IMAGE_YADAGE: "reanahub/reana-workflow-engine-yadage:latest"
+      - REANA_WORKFLOW_ENGINE_IMAGE_SERIAL: "reanahub/reana-workflow-engine-serial:latest"
 
   reana-server:
     type: "docker"
-    image: "reanahub/reana-server:0.6.0"
+    image: "reanahub/reana-server:latest"
     environment:
       - <<: *db_base_config
 
   reana-message-broker:
     type: "docker"
-    image: "reanahub/reana-message-broker:0.6.0"
+    image: "reanahub/reana-message-broker:latest"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'click>=7',
     'Jinja2>=2.9.6,<2.11',
     'PyYAML>=5.1',
-    'reana-commons[kubernetes]>=0.6.0,<0.7.0',
+    'reana-commons[kubernetes]>=0.6.1,<0.7.0',
     'tablib>=0.12.1,<0.13',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
+    'reana-db>=0.6.0,<0.7.0',
     'pytest-reana>=0.6.0,<0.7.0',
 ]
 


### PR DESCRIPTION
* For Minikube installations, 'latest' images should be used, otherwise
  local developments e.g. in reana-job-controller aren't taken into
  account when using `make` commands.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>